### PR TITLE
lib: use buffer-xor over inline

### DIFF
--- a/lib/bip38.js
+++ b/lib/bip38.js
@@ -3,22 +3,12 @@ var assert = require('assert')
 var createHash = require('create-hash')
 var cs = require('coinstring')
 var scrypt = require('scryptsy')
+var xor = require('buffer-xor')
 
 var ecurve = require('ecurve')
 var curve = ecurve.getCurveByName('secp256k1')
 
 var BigInteger = require('bigi')
-
-function bufferXOR (buf1, buf2) {
-  assert.equal(buf1.length, buf2.length)
-
-  var out = new Buffer(buf1.length)
-  for (var i = 0; i < buf1.length; i++) {
-    out[i] = buf1[i] ^ buf2[i]
-  }
-
-  return out
-}
 
 // SHA256(SHA256(buffer))
 function sha256x2 (buffer) {
@@ -54,7 +44,7 @@ Bip38.prototype.encryptRaw = function (buffer, compressed, passphrase, saltAddre
   var derivedHalf1 = scryptBuf.slice(0, 32)
   var derivedHalf2 = scryptBuf.slice(32, 64)
 
-  var xorBuf = bufferXOR(buffer, derivedHalf1)
+  var xorBuf = xor(buffer, derivedHalf1)
   var cipher = aes.createCipheriv('aes-256-ecb', derivedHalf2, new Buffer(0))
   cipher.setAutoPadding(false)
   cipher.end(xorBuf)
@@ -123,7 +113,7 @@ Bip38.prototype.decryptRaw = function (encData, passphrase) {
   decipher.end(privKeyBuf)
 
   var plainText = decipher.read()
-  var privateKey = bufferXOR(plainText, derivedHalf1)
+  var privateKey = xor(plainText, derivedHalf1)
 
   return {
     privateKey: privateKey,
@@ -200,7 +190,7 @@ Bip38.prototype.decryptECMult = function (encData, passphrase) {
   decipher.end(encryptedPart2)
 
   var decryptedPart2 = decipher.read()
-  var tmp = bufferXOR(decryptedPart2, derivedHalf1.slice(16, 32))
+  var tmp = xor(decryptedPart2, derivedHalf1.slice(16, 32))
   var seedBPart2 = tmp.slice(8, 16)
 
   var decipher2 = aes.createDecipheriv('aes-256-ecb', derivedHalf2, new Buffer(0))
@@ -208,7 +198,7 @@ Bip38.prototype.decryptECMult = function (encData, passphrase) {
   decipher2.write(encryptedPart1) // first 8 bytes
   decipher2.end(tmp.slice(0, 8)) // last 8 bytes
 
-  var seedBPart1 = bufferXOR(decipher2.read(), derivedHalf1.slice(0, 16))
+  var seedBPart1 = xor(decipher2.read(), derivedHalf1.slice(0, 16))
   var seedB = Buffer.concat([seedBPart1, seedBPart2], 24)
   var factorB = sha256x2(seedB)
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "bigi": "^1.2.0",
     "browserify-aes": "^1.0.1",
+    "buffer-xor": "^1.0.2",
     "coinstring": "^2.2.0",
     "create-hash": "^1.1.1",
     "ecurve": "^1.0.0",


### PR DESCRIPTION
I've written [this](https://github.com/crypto-browserify/buffer-xor) function enough times :), why not? Eh @jprichardson haha

*edit:* Maybe wait out on https://github.com/crypto-browserify/buffer-xor/issues/1?